### PR TITLE
Small fix for error: PHP Warning:  shell_exec() has been disabled

### DIFF
--- a/ProgressBar.php
+++ b/ProgressBar.php
@@ -330,7 +330,8 @@ class ProgressBar
     protected static function setWidth($width = null)
     {
         if ($width === null) {
-            if (DIRECTORY_SEPARATOR === '/') {
+            $disabled = explode(',', ini_get('disable_functions'));
+            if (DIRECTORY_SEPARATOR === '/' && !in_array('shell_exec', $disabled) && posix_isatty(0)) {
                 $width = `tput cols`;
             }
             if ($width < 80) {


### PR DESCRIPTION
Small fix for error: PHP Warning:  shell_exec() has been disabled for security reasons in /var/www/html/php-cli-progress-bar/ProgressBar.php on line 334, the setWith() function checks the disabled_function also check posix_isatty() to validate if the current terminal session is a TTY or not.